### PR TITLE
Update to dhall > 1.19

### DIFF
--- a/dhall-nix.cabal
+++ b/dhall-nix.cabal
@@ -28,9 +28,9 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                      >= 4.8.0.0 && < 5   ,
-        containers                              < 0.6 ,
+        containers                              < 0.7 ,
         data-fix                                < 0.3 ,
-        dhall                     >= 1.15    && < 1.18,
+        dhall                     >= 1.19    && < 1.22,
         hnix                      >= 0.5     && < 0.6 ,
         insert-ordered-containers >= 0.1.0.1 && < 0.3 ,
         neat-interpolation                      < 0.4 ,

--- a/dhall-nix.cabal
+++ b/dhall-nix.cabal
@@ -31,8 +31,7 @@ Library
         containers                              < 0.7 ,
         data-fix                                < 0.3 ,
         dhall                     >= 1.19    && < 1.22,
-        hnix                      >= 0.5     && < 0.6 ,
-        insert-ordered-containers >= 0.1.0.1 && < 0.3 ,
+        hnix                      >= 0.5     && < 0.7 ,
         neat-interpolation                      < 0.4 ,
         text                      >= 0.8.0.0 && < 1.3
     Exposed-Modules:

--- a/nix/QuickCheck.nix
+++ b/nix/QuickCheck.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, containers, deepseq, erf, process, random
+, stdenv, template-haskell, tf-random, transformers
+}:
+mkDerivation {
+  pname = "QuickCheck";
+  version = "2.12.6.1";
+  sha256 = "0b2aa7f5c625b5875c36f5f548926fcdaedf4311bd3a4c291fcf10b8d7faa170";
+  revision = "1";
+  editedCabalFile = "0w5gygp6pmyjzjjx5irfflcbx586zfnqidq669ssqqfsadf944xv";
+  libraryHaskellDepends = [
+    base containers deepseq erf random template-haskell tf-random
+    transformers
+  ];
+  testHaskellDepends = [ base deepseq process ];
+  homepage = "https://github.com/nick8325/quickcheck";
+  description = "Automatic testing of Haskell programs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/aeson.nix
+++ b/nix/aeson.nix
@@ -1,0 +1,33 @@
+{ mkDerivation, attoparsec, base, base-compat, base-orphans
+, base16-bytestring, bytestring, containers, contravariant, deepseq
+, directory, dlist, filepath, generic-deriving, ghc-prim, hashable
+, hashable-time, integer-logarithms, primitive, QuickCheck
+, quickcheck-instances, scientific, stdenv, tagged, tasty
+, tasty-hunit, tasty-quickcheck, template-haskell, text
+, th-abstraction, time, time-locale-compat, unordered-containers
+, uuid-types, vector
+}:
+mkDerivation {
+  pname = "aeson";
+  version = "1.4.2.0";
+  sha256 = "75ce71814a33d5e5568208e6806a8847e7ba47fea74d30f6a8b1b56ecb318bd0";
+  revision = "1";
+  editedCabalFile = "067y82gq86740j2zj4y6v7z9b5860ncg2g9lfnrpsnb9jqm7arl1";
+  libraryHaskellDepends = [
+    attoparsec base base-compat bytestring containers contravariant
+    deepseq dlist ghc-prim hashable primitive scientific tagged
+    template-haskell text th-abstraction time time-locale-compat
+    unordered-containers uuid-types vector
+  ];
+  testHaskellDepends = [
+    attoparsec base base-compat base-orphans base16-bytestring
+    bytestring containers directory dlist filepath generic-deriving
+    ghc-prim hashable hashable-time integer-logarithms QuickCheck
+    quickcheck-instances scientific tagged tasty tasty-hunit
+    tasty-quickcheck template-haskell text time time-locale-compat
+    unordered-containers uuid-types vector
+  ];
+  homepage = "https://github.com/bos/aeson";
+  description = "Fast JSON parsing and encoding";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/base-compat.nix
+++ b/nix/base-compat.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, base, stdenv, unix }:
+mkDerivation {
+  pname = "base-compat";
+  version = "0.10.5";
+  sha256 = "990aea21568956d44ab018c5dbfbaea014b9a0d5295d29ca7550149419a6fb41";
+  libraryHaskellDepends = [ base unix ];
+  description = "A compatibility layer for base";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/base-orphans.nix
+++ b/nix/base-orphans.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, ghc-prim, hspec, hspec-discover, QuickCheck
+, stdenv
+}:
+mkDerivation {
+  pname = "base-orphans";
+  version = "0.8.1";
+  sha256 = "442bd63aed102e753b2fed15df8ae19f35ee07af26590da63837c523b64a99db";
+  libraryHaskellDepends = [ base ghc-prim ];
+  testHaskellDepends = [ base hspec QuickCheck ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/haskell-compat/base-orphans#readme";
+  description = "Backwards-compatible orphan instances for base";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/cborg-json.nix
+++ b/nix/cborg-json.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, aeson, aeson-pretty, base, cborg, scientific
+, stdenv, text, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "cborg-json";
+  version = "0.2.1.0";
+  sha256 = "3fb6b54e6ddd322880689fb461f7911aca45b9758482c9f9949619c7d7b52006";
+  libraryHaskellDepends = [
+    aeson aeson-pretty base cborg scientific text unordered-containers
+    vector
+  ];
+  homepage = "https://github.com/well-typed/cborg";
+  description = "A library for encoding JSON as CBOR";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/contravariant.nix
+++ b/nix/contravariant.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, StateVar, stdenv, transformers }:
+mkDerivation {
+  pname = "contravariant";
+  version = "1.5";
+  sha256 = "6ef067b692ad69ffff294b953aa85f3ded459d4ae133c37896222a09280fc3c2";
+  libraryHaskellDepends = [ base StateVar transformers ];
+  homepage = "http://github.com/ekmett/contravariant/";
+  description = "Contravariant functors";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/dhall-nix.nix
+++ b/nix/dhall-nix.nix
@@ -1,6 +1,5 @@
 { mkDerivation, base, containers, data-fix, dhall, hnix
-, insert-ordered-containers, neat-interpolation, optparse-generic
-, stdenv, text
+, neat-interpolation, optparse-generic, stdenv, text
 }:
 mkDerivation {
   pname = "dhall-nix";
@@ -9,8 +8,7 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base containers data-fix dhall hnix insert-ordered-containers
-    neat-interpolation text
+    base containers data-fix dhall hnix neat-interpolation text
   ];
   executableHaskellDepends = [
     base dhall hnix optparse-generic text

--- a/nix/dhall.nix
+++ b/nix/dhall.nix
@@ -1,35 +1,37 @@
-{ mkDerivation, ansi-terminal, base, bytestring, case-insensitive
-, cborg, containers, contravariant, criterion, cryptonite, deepseq
-, Diff, directory, doctest, exceptions, filepath, hashable
-, haskeline, http-client, http-client-tls
-, insert-ordered-containers, lens-family-core, megaparsec, memory
+{ mkDerivation, aeson, aeson-pretty, ansi-terminal, base
+, bytestring, case-insensitive, cborg, cborg-json, containers
+, contravariant, criterion, cryptonite, deepseq, Diff, directory
+, doctest, dotgen, exceptions, filepath, haskeline, http-client
+, http-client-tls, http-types, lens-family-core, megaparsec, memory
 , mockery, mtl, optparse-applicative, parsers, prettyprinter
 , prettyprinter-ansi-terminal, QuickCheck, quickcheck-instances
 , repline, scientific, serialise, stdenv, tasty, tasty-hunit
 , tasty-quickcheck, template-haskell, text, transformers
-, unordered-containers, vector
+, unordered-containers, uri-encode, vector
 }:
 mkDerivation {
   pname = "dhall";
-  version = "1.17.0";
-  sha256 = "a029fea856224a79f0b7cc56fbb5c566d0dfd1d915d214f682006cabf1274791";
+  version = "1.21.0";
+  sha256 = "9b22cc6f7694ef2f5d5d6fa66727044622b9905b2a9da0cdf376c75ad3b9df0e";
+  revision = "1";
+  editedCabalFile = "0ap1490jks9hmwf73vlrj7bsfrf4m5yvgqxx3ix57w23ia5gy662";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-terminal base bytestring case-insensitive cborg containers
-    contravariant cryptonite Diff directory exceptions filepath
-    hashable haskeline http-client http-client-tls
-    insert-ordered-containers lens-family-core megaparsec memory mtl
+    aeson aeson-pretty ansi-terminal base bytestring case-insensitive
+    cborg cborg-json containers contravariant cryptonite Diff directory
+    dotgen exceptions filepath haskeline http-client http-client-tls
+    http-types lens-family-core megaparsec memory mtl
     optparse-applicative parsers prettyprinter
     prettyprinter-ansi-terminal repline scientific serialise
-    template-haskell text transformers unordered-containers vector
+    template-haskell text transformers unordered-containers uri-encode
+    vector
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    base containers deepseq directory doctest filepath hashable
-    insert-ordered-containers mockery prettyprinter QuickCheck
-    quickcheck-instances serialise tasty tasty-hunit tasty-quickcheck
-    text transformers vector
+    base bytestring cborg containers deepseq directory doctest filepath
+    mockery prettyprinter QuickCheck quickcheck-instances serialise
+    tasty tasty-hunit tasty-quickcheck text transformers vector
   ];
   benchmarkHaskellDepends = [
     base bytestring containers criterion directory serialise text

--- a/nix/free.nix
+++ b/nix/free.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, comonad, containers, distributive, exceptions
+, mtl, profunctors, semigroupoids, stdenv, template-haskell
+, transformers, transformers-base
+}:
+mkDerivation {
+  pname = "free";
+  version = "5.1";
+  sha256 = "70424d5c82dea36a0a29c4f5f6bc047597a947ad46f3d66312e47bbee2eeea84";
+  libraryHaskellDepends = [
+    base comonad containers distributive exceptions mtl profunctors
+    semigroupoids template-haskell transformers transformers-base
+  ];
+  homepage = "http://github.com/ekmett/free/";
+  description = "Monads for free";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/hnix-store-core.nix
+++ b/nix/hnix-store-core.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, base, base16-bytestring, base64-bytestring, binary
+, bytestring, containers, cryptohash-md5, cryptohash-sha1
+, cryptohash-sha256, directory, filepath, hashable, mtl, process
+, regex-base, regex-tdfa-text, stdenv, tasty, tasty-discover
+, tasty-hspec, tasty-hunit, tasty-quickcheck, temporary, text, unix
+, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "hnix-store-core";
+  version = "0.1.0.0";
+  sha256 = "878c9a1dcb535b76efb7af392f9a9e75b954ce4ebb75acac91036a6c3c1d3df7";
+  libraryHaskellDepends = [
+    base base16-bytestring binary bytestring containers cryptohash-md5
+    cryptohash-sha1 cryptohash-sha256 directory filepath hashable mtl
+    regex-base regex-tdfa-text text unix unordered-containers vector
+  ];
+  testHaskellDepends = [
+    base base64-bytestring binary bytestring containers directory
+    process tasty tasty-discover tasty-hspec tasty-hunit
+    tasty-quickcheck temporary text
+  ];
+  testToolDepends = [ tasty-discover ];
+  homepage = "https://github.com/haskell-nix/hnix-store";
+  description = "Core effects for interacting with the Nix store";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/nix/hnix.nix
+++ b/nix/hnix.nix
@@ -1,0 +1,67 @@
+{ mkDerivation, aeson, array, base, base16-bytestring, binary
+, bytestring, comonad, containers, contravariant, criterion
+, cryptohash-md5, cryptohash-sha1, cryptohash-sha256
+, cryptohash-sha512, data-fix, deepseq, dependent-sum
+, deriving-compat, Diff, directory, exceptions, fetchgit, filepath
+, free, generic-random, Glob, hashable, hashing, haskeline
+, hedgehog, hnix-store-core, http-client, http-client-tls
+, http-types, interpolate, lens-family, lens-family-core
+, lens-family-th, logict, megaparsec, monad-control, monadlist, mtl
+, optparse-applicative, parser-combinators, pretty-show
+, prettyprinter, process, ref-tf, regex-tdfa, regex-tdfa-text
+, repline, scientific, semigroups, serialise, split, stdenv, syb
+, tasty, tasty-hedgehog, tasty-hunit, tasty-quickcheck, tasty-th
+, template-haskell, text, these, time, transformers
+, transformers-base, unix, unordered-containers, vector, xml
+}:
+mkDerivation {
+  pname = "hnix";
+  version = "0.6.0";
+  src = fetchgit {
+    url = "https://github.com/haskell-nix/hnix.git";
+    sha256 = "15g4brrl8qj5dhx54x0rc4212q11bljvv4wh5qz199p2pk7gbqwk";
+    rev = "3d89159ee425bf4671a6e4a610c1527d7ce251a9";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson array base base16-bytestring binary bytestring comonad
+    containers contravariant cryptohash-md5 cryptohash-sha1
+    cryptohash-sha256 cryptohash-sha512 data-fix deepseq dependent-sum
+    deriving-compat directory exceptions filepath free hashable hashing
+    haskeline hnix-store-core http-client http-client-tls http-types
+    interpolate lens-family lens-family-core lens-family-th logict
+    megaparsec monad-control monadlist mtl optparse-applicative
+    parser-combinators pretty-show prettyprinter process ref-tf
+    regex-tdfa regex-tdfa-text scientific semigroups serialise split
+    syb template-haskell text these time transformers transformers-base
+    unix unordered-containers vector xml
+  ];
+  executableHaskellDepends = [
+    aeson base base16-bytestring bytestring comonad containers
+    cryptohash-md5 cryptohash-sha1 cryptohash-sha256 cryptohash-sha512
+    data-fix deepseq exceptions filepath free hashing haskeline mtl
+    optparse-applicative pretty-show prettyprinter ref-tf repline
+    serialise template-haskell text time transformers
+    unordered-containers
+  ];
+  testHaskellDepends = [
+    base base16-bytestring bytestring containers cryptohash-md5
+    cryptohash-sha1 cryptohash-sha256 cryptohash-sha512 data-fix
+    deepseq dependent-sum Diff directory exceptions filepath
+    generic-random Glob hashing hedgehog interpolate megaparsec mtl
+    optparse-applicative pretty-show prettyprinter process serialise
+    split tasty tasty-hedgehog tasty-hunit tasty-quickcheck tasty-th
+    template-haskell text time transformers unix unordered-containers
+  ];
+  benchmarkHaskellDepends = [
+    base base16-bytestring bytestring containers criterion
+    cryptohash-md5 cryptohash-sha1 cryptohash-sha256 cryptohash-sha512
+    data-fix deepseq exceptions filepath hashing mtl
+    optparse-applicative serialise template-haskell text time
+    transformers unordered-containers
+  ];
+  homepage = "https://github.com/haskell-nix/hnix#readme";
+  description = "Haskell implementation of the Nix language";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/http-client.nix
+++ b/nix/http-client.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, array, async, base, blaze-builder, bytestring
+, case-insensitive, containers, cookie, deepseq, directory
+, exceptions, filepath, ghc-prim, hspec, http-types, memory
+, mime-types, monad-control, network, network-uri, random, stdenv
+, stm, streaming-commons, text, time, transformers, zlib
+}:
+mkDerivation {
+  pname = "http-client";
+  version = "0.5.14";
+  sha256 = "8e50409704021c51a8955b2d03bfec900ebc3e11fbaebf973f2e654d7bde3647";
+  revision = "1";
+  editedCabalFile = "0xw5ac4cvcd4hcwl7j12adi7sgffjryqhk0x992k3qs1cxyv5028";
+  libraryHaskellDepends = [
+    array base blaze-builder bytestring case-insensitive containers
+    cookie deepseq exceptions filepath ghc-prim http-types memory
+    mime-types network network-uri random stm streaming-commons text
+    time transformers
+  ];
+  testHaskellDepends = [
+    async base blaze-builder bytestring case-insensitive containers
+    deepseq directory hspec http-types monad-control network
+    network-uri streaming-commons text time transformers zlib
+  ];
+  doCheck = false;
+  homepage = "https://github.com/snoyberg/http-client";
+  description = "An HTTP client engine";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/http-types.nix
+++ b/nix/http-types.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, array, base, bytestring, case-insensitive, doctest
+, hspec, QuickCheck, quickcheck-instances, stdenv, text
+}:
+mkDerivation {
+  pname = "http-types";
+  version = "0.12.3";
+  sha256 = "4e8a4a66477459fa436a331c75e46857ec8026283df984d54f90576cd3024016";
+  libraryHaskellDepends = [
+    array base bytestring case-insensitive text
+  ];
+  testHaskellDepends = [
+    base bytestring doctest hspec QuickCheck quickcheck-instances text
+  ];
+  homepage = "https://github.com/aristidb/http-types";
+  description = "Generic HTTP types for Haskell (for both client and server code)";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/lens.nix
+++ b/nix/lens.nix
@@ -1,0 +1,39 @@
+{ mkDerivation, array, base, base-orphans, bifunctors, bytestring
+, Cabal, cabal-doctest, call-stack, comonad, containers
+, contravariant, criterion, deepseq, directory, distributive
+, doctest, exceptions, filepath, free, generic-deriving, ghc-prim
+, hashable, HUnit, kan-extensions, mtl, nats, parallel, profunctors
+, QuickCheck, reflection, semigroupoids, semigroups, simple-reflect
+, stdenv, tagged, template-haskell, test-framework
+, test-framework-hunit, test-framework-quickcheck2
+, test-framework-th, text, th-abstraction, transformers
+, transformers-compat, unordered-containers, vector, void
+}:
+mkDerivation {
+  pname = "lens";
+  version = "4.17";
+  sha256 = "473664de541023bef44aa29105abbb1e35542e9254cdc846963183e0dd3f08cc";
+  setupHaskellDepends = [ base Cabal cabal-doctest filepath ];
+  libraryHaskellDepends = [
+    array base base-orphans bifunctors bytestring call-stack comonad
+    containers contravariant distributive exceptions filepath free
+    ghc-prim hashable kan-extensions mtl parallel profunctors
+    reflection semigroupoids semigroups tagged template-haskell text
+    th-abstraction transformers transformers-compat
+    unordered-containers vector void
+  ];
+  testHaskellDepends = [
+    base bytestring containers deepseq directory doctest filepath
+    generic-deriving HUnit mtl nats parallel QuickCheck semigroups
+    simple-reflect test-framework test-framework-hunit
+    test-framework-quickcheck2 test-framework-th text transformers
+    unordered-containers vector
+  ];
+  benchmarkHaskellDepends = [
+    base bytestring comonad containers criterion deepseq
+    generic-deriving transformers unordered-containers vector
+  ];
+  homepage = "http://github.com/ekmett/lens/";
+  description = "Lenses, Folds and Traversals";
+  license = stdenv.lib.licenses.bsd2;
+}

--- a/nix/megaparsec.nix
+++ b/nix/megaparsec.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, criterion, deepseq, hspec, hspec-expectations, mtl
+, parser-combinators, QuickCheck, scientific, stdenv, text
+, transformers, weigh
+}:
+mkDerivation {
+  pname = "megaparsec";
+  version = "7.0.4";
+  sha256 = "325ba5cee8cdef91e351fb2db0b38562f8345b0bcdfed97045671357501de8c1";
+  libraryHaskellDepends = [
+    base bytestring case-insensitive containers deepseq mtl
+    parser-combinators scientific text transformers
+  ];
+  testHaskellDepends = [
+    base bytestring case-insensitive containers hspec
+    hspec-expectations mtl parser-combinators QuickCheck scientific
+    text transformers
+  ];
+  benchmarkHaskellDepends = [
+    base containers criterion deepseq text weigh
+  ];
+  homepage = "https://github.com/mrkkrp/megaparsec";
+  description = "Monadic parser combinators";
+  license = stdenv.lib.licenses.bsd2;
+}

--- a/nix/neat-interpolation.nix
+++ b/nix/neat-interpolation.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, base-prelude, HTF, megaparsec, stdenv
+, template-haskell, text
+}:
+mkDerivation {
+  pname = "neat-interpolation";
+  version = "0.3.2.4";
+  sha256 = "de7370d938ffd8c7b52d732f4f088387ed8216cf9767d818e99b7ec827931752";
+  libraryHaskellDepends = [
+    base base-prelude megaparsec template-haskell text
+  ];
+  testHaskellDepends = [ base-prelude HTF ];
+  homepage = "https://github.com/nikita-volkov/neat-interpolation";
+  description = "A quasiquoter for neat and simple multiline text interpolation";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/optparse-applicative.nix
+++ b/nix/optparse-applicative.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, ansi-wl-pprint, base, bytestring, process
+, QuickCheck, stdenv, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "optparse-applicative";
+  version = "0.14.3.0";
+  sha256 = "72476302fe555a508917b2d7d6121c7b58ea5434cdc08aeb5d4b652e8f0e7663";
+  libraryHaskellDepends = [
+    ansi-wl-pprint base process transformers transformers-compat
+  ];
+  testHaskellDepends = [ base bytestring QuickCheck ];
+  homepage = "https://github.com/pcapriotti/optparse-applicative";
+  description = "Utilities and combinators for parsing command line options";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/parser-combinators.nix
+++ b/nix/parser-combinators.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, stdenv }:
+mkDerivation {
+  pname = "parser-combinators";
+  version = "1.0.1";
+  sha256 = "edf5ab8fa69a04334baa8707252036563a8339a96a86956c90febe93830cea32";
+  libraryHaskellDepends = [ base ];
+  homepage = "https://github.com/mrkkrp/parser-combinators";
+  description = "Lightweight package providing commonly useful parser combinators";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/pretty-show.nix
+++ b/nix/pretty-show.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, array, base, filepath, ghc-prim, happy
+, haskell-lexer, pretty, stdenv, text
+}:
+mkDerivation {
+  pname = "pretty-show";
+  version = "1.9.5";
+  sha256 = "b095bebb79951d2e25a543a591844fb638165672d7b95d325844611297ba423f";
+  isLibrary = true;
+  isExecutable = true;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    array base filepath ghc-prim haskell-lexer pretty text
+  ];
+  libraryToolDepends = [ happy ];
+  executableHaskellDepends = [ base ];
+  homepage = "http://wiki.github.com/yav/pretty-show";
+  description = "Tools for working with derived `Show` instances and generic inspection of values";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/repline.nix
+++ b/nix/repline.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, base, containers, haskeline, mtl, process, stdenv
+}:
+mkDerivation {
+  pname = "repline";
+  version = "0.2.0.0";
+  sha256 = "ecc72092d0340b896ee6bf96bf6645694dbcd33361725a2cd28c5ab5d60c02de";
+  libraryHaskellDepends = [ base containers haskeline mtl process ];
+  homepage = "https://github.com/sdiehl/repline";
+  description = "Haskeline wrapper for GHCi-like REPL interfaces";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/semigroupoids.nix
+++ b/nix/semigroupoids.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, base-orphans, bifunctors, Cabal
+, cabal-doctest, comonad, containers, contravariant, distributive
+, doctest, hashable, stdenv, tagged, template-haskell, transformers
+, transformers-compat, unordered-containers
+}:
+mkDerivation {
+  pname = "semigroupoids";
+  version = "5.3.2";
+  sha256 = "61a8213df437ee96a20b1c6dec8b5c573e4e0f338eb2061739a67f471d6b9d05";
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    base base-orphans bifunctors comonad containers contravariant
+    distributive hashable tagged template-haskell transformers
+    transformers-compat unordered-containers
+  ];
+  testHaskellDepends = [ base doctest ];
+  homepage = "http://github.com/ekmett/semigroupoids";
+  description = "Semigroupoids: Category sans id";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/serialise.nix
+++ b/nix/serialise.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, aeson, array, base, binary, bytestring, cborg
+, cereal, cereal-vector, containers, criterion, deepseq, directory
+, filepath, ghc-prim, half, hashable, pretty, primitive, QuickCheck
+, quickcheck-instances, semigroups, stdenv, store, tar, tasty
+, tasty-hunit, tasty-quickcheck, text, time, unordered-containers
+, vector, zlib
+}:
+mkDerivation {
+  pname = "serialise";
+  version = "0.2.1.0";
+  sha256 = "043efc1130b4202f080c5b7d2c319098df032b060655d8193f1fcdbfa3f159a5";
+  libraryHaskellDepends = [
+    array base bytestring cborg containers ghc-prim half hashable
+    primitive text time unordered-containers vector
+  ];
+  testHaskellDepends = [
+    base bytestring cborg containers directory filepath primitive
+    QuickCheck quickcheck-instances tasty tasty-hunit tasty-quickcheck
+    text time unordered-containers vector
+  ];
+  benchmarkHaskellDepends = [
+    aeson array base binary bytestring cborg cereal cereal-vector
+    containers criterion deepseq directory filepath ghc-prim half
+    pretty semigroups store tar text time vector zlib
+  ];
+  homepage = "https://github.com/well-typed/cborg";
+  description = "A binary serialisation library for Haskell values";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/these.nix
+++ b/nix/these.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, aeson, base, base-compat, bifunctors, binary
+, containers, data-default-class, deepseq, hashable, keys, lens
+, mtl, QuickCheck, quickcheck-instances, semigroupoids, stdenv
+, tasty, tasty-quickcheck, transformers, transformers-compat
+, unordered-containers, vector, vector-instances
+}:
+mkDerivation {
+  pname = "these";
+  version = "0.7.6";
+  sha256 = "9464b83d98e626360a8ad9836ba77e5201cd1e9c89b95b1b11a28ef3c23ac746";
+  libraryHaskellDepends = [
+    aeson base base-compat bifunctors binary containers
+    data-default-class deepseq hashable keys lens mtl QuickCheck
+    semigroupoids transformers transformers-compat unordered-containers
+    vector vector-instances
+  ];
+  testHaskellDepends = [
+    aeson base base-compat bifunctors binary containers hashable lens
+    QuickCheck quickcheck-instances tasty tasty-quickcheck transformers
+    unordered-containers vector
+  ];
+  homepage = "https://github.com/isomorphism/these";
+  description = "An either-or-both data type & a generalized 'zip with padding' typeclass";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/time-locale-compat.nix
+++ b/nix/time-locale-compat.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, old-locale, stdenv, time }:
+mkDerivation {
+  pname = "time-locale-compat";
+  version = "0.1.1.5";
+  sha256 = "07ff1566de7d851423a843b2de385442319348c621d4f779b3d365ce91ac502c";
+  libraryHaskellDepends = [ base old-locale time ];
+  homepage = "https://github.com/khibino/haskell-time-locale-compat";
+  description = "Compatibile module for time-format locale";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/vector.nix
+++ b/nix/vector.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, base-orphans, deepseq, ghc-prim, HUnit
+, primitive, QuickCheck, random, stdenv, template-haskell
+, test-framework, test-framework-hunit, test-framework-quickcheck2
+, transformers
+}:
+mkDerivation {
+  pname = "vector";
+  version = "0.12.0.2";
+  sha256 = "52e89dacaff10bedb8653181963cae928f9674a099bb706713dae83994bbc0f3";
+  libraryHaskellDepends = [ base deepseq ghc-prim primitive ];
+  testHaskellDepends = [
+    base base-orphans HUnit primitive QuickCheck random
+    template-haskell test-framework test-framework-hunit
+    test-framework-quickcheck2 transformers
+  ];
+  homepage = "https://github.com/haskell/vector";
+  description = "Efficient Arrays";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/release.nix
+++ b/release.nix
@@ -9,25 +9,84 @@ let
     outputSha256 = "0xpqc1fhkvvv5dv1zmas2j1q27mi7j7dgyjcdh82mlgl1q63i660";
   };
 
+  mass = function: names: haskellPackagesNew: haskellPackagesOld:
+    let
+      toNameValue = name: {
+        inherit name;
+
+        value = function haskellPackagesOld."${name}";
+      };
+
+    in
+      builtins.listToAttrs (map toNameValue names);
+
   config = {
     packageOverrides = pkgs: {
-      haskellPackages = pkgs.haskellPackages.override {
-        overrides = haskellPackagesNew: haskellPackagesOld: {
-          cryptohash-sha512 =
-            pkgs.haskell.lib.dontCheck haskellPackagesOld.cryptohash-sha512;
+      haskellPackages = pkgs.haskellPackages.override (old: {
+          overrides =
+            let
+              dontCheck =
+                mass pkgs.haskell.lib.dontCheck [
+                  "adjunctions"
+                  "base-orphans"
+                  "base64-bytestring"
+                  "cereal"
+                  "blaze-builder"
+                  "neat-interpolation"
+                  "pureMD5"
+                  "pem"
+                  "lens"
+                  "th-orphans"
+                  "mockery"
+                  "megaparsec"
+                  "lens-family-th"
+                  "network-uri"
+                  "invariant"
+                  "interpolate"
+                  "http-types"
+                  "parsers"
+                  "dhall"
+                  "aeson"
+                  "half"
+                  "generic-deriving"
+                  "distributive"
+                  "deriving-compat"
+                  "monad-control"
+                  "logging-facade"
+                  "bifunctors"
+                  "exceptions"
+                  "cborg-json"
+                  "cryptohash-sha512"
+                  "Diff"
+                  "hashable"
+                  "hnix"
+                  "hnix-store-core"
+                  "optparse-generic"
+                  "serialise"
+                  "SHA"
+                  "these"
+                  "unordered-containers"
+                  "vector"
+                ];
 
-          dhall = haskellPackagesNew.callPackage ./nix/dhall.nix { };
+              extension = haskellPackagesNew: haskellPackagesOld: {
+                dhall-nix =
+                  pkgs.haskell.lib.failOnAllWarnings
+                    (pkgs.haskell.lib.justStaticExecutables
+                      haskellPackagesOld.dhall-nix
+                    );
+              };
 
-          dhall-nix =
-            pkgs.haskell.lib.failOnAllWarnings
-              (pkgs.haskell.lib.justStaticExecutables
-                (haskellPackagesNew.callPackage ./nix/dhall-nix.nix { })
-              );
-
-          serialise =
-            pkgs.haskell.lib.dontCheck haskellPackagesOld.serialise;
-        };
-      };
+            in
+              pkgs.lib.fold
+                pkgs.lib.composeExtensions
+                (old.overrides or (_: _: {}))
+                [ (pkgs.haskell.lib.packagesFromDirectory { directory = ./nix; })
+                  dontCheck
+                  extension
+                ];
+        }
+      );
     };
   };
 
@@ -39,7 +98,7 @@ let
 in
   { dhall-nix = pkgs.haskellPackages.dhall-nix;
 
-    shell = (pkgs.haskell.lib.addBuildTool pkgs.haskellPackages.dhall-nix pkgs.cabal-install).env;
+    shell = pkgs.haskellPackages.dhall-nix.env;
 
     # Test that various Dhall to Nix conversions work
     tests =

--- a/release.nix
+++ b/release.nix
@@ -135,6 +135,8 @@ in
             → if b then just 1 else nothing
             )
         '';
+        testNone = dhallToNix "None Natural";
+        testSome = dhallToNix "Some 4";
         testRecord = dhallToNix "{}";
         testRecordLit = dhallToNix "{ foo = 1, bar = True}";
         testUnion = dhallToNix "< Left : Natural | Right : Bool >";


### PR DESCRIPTION
Some things have changed in the dhall expression tree:

- `let` bindings now take a list of bindings
- `Some` and `None` were introduced

Additionally, dhall switched to an internal `Map` module instead of
`HashMap.Strict.InsOrd`.

I haven’t found any instructions on how the `dhall.nix` files are generated, I used my own overrides to work on this. Probably something with `cabal2nix`, but its usage is not at all clear to me (and the errors it throws unhelpful).